### PR TITLE
[tinkerforge-bindings] fix windows builds

### DIFF
--- a/recipes/tinkerforge-bindings/all/CMakeLists.txt
+++ b/recipes/tinkerforge-bindings/all/CMakeLists.txt
@@ -7,12 +7,14 @@ conan_basic_setup(TARGETS)
 file(GLOB SOURCES ${CMAKE_SOURCE_DIR}/source_subfolder/source/*.c)
 file(GLOB HEADERS ${CMAKE_SOURCE_DIR}/source_subfolder/source/*.h)
 
-add_library(${PROJECT_NAME} ${SOURCES})
-if(MSVC)
-        target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32 advapi32)
-endif()
 if(WIN32 AND BUILD_SHARED_LIBS)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
+add_library(${PROJECT_NAME} ${SOURCES})
+
+if(MSVC)
+        target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32 advapi32)
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${HEADERS}")

--- a/recipes/tinkerforge-bindings/all/conanfile.py
+++ b/recipes/tinkerforge-bindings/all/conanfile.py
@@ -70,13 +70,13 @@ class TinkerforgeBindingsConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.set_property("cmake_target_name", "tinkerforge::bindings")
+        self.cpp_info.set_property("cmake_target_name", "tinkerforge-bindings")
         self.cpp_info.set_property("cmake_find_mode", "both")
 
-        self.cpp_info.names["cmake_find_package"] = "tinkerforge" 
-        self.cpp_info.names["cmake_find_package_multi"] = "tinkerforge" 
-        self.cpp_info.filenames["cmake_find_package"] = "tinkerforge-bindings" 
-        self.cpp_info.filenames["cmake_find_package_multi"] = "tinkerforge-bindings" 
+        self.cpp_info.names["cmake_find_package"] = "tinkerforge"
+        self.cpp_info.names["cmake_find_package_multi"] = "tinkerforge"
+        self.cpp_info.filenames["cmake_find_package"] = "tinkerforge-bindings"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "tinkerforge-bindings"
         self.cpp_info.components["_bindings"].names["cmake_find_package"] = "bindings"
         self.cpp_info.components["_bindings"].names["cmake_find_package_multi"] = "bindings"
         self.cpp_info.components["_bindings"].libs = ["tinkerforge_bindings"]

--- a/recipes/tinkerforge-bindings/all/test_package/CMakeLists.txt
+++ b/recipes/tinkerforge-bindings/all/test_package/CMakeLists.txt
@@ -7,4 +7,4 @@ conan_basic_setup(TARGETS)
 find_package(tinkerforge-bindings REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} tinkerforge::bindings)
+target_link_libraries(${PROJECT_NAME} tinkerforge-bindings::tinkerforge-bindings)


### PR DESCRIPTION
- Fixed *.lib* file not generated on Windows shared config.
- Fixed CMake error with variables names containing `:` chars: `tinkerforge::bindings_bindings_INCLUDE_DIRS` and so failed when using its values in strings with this syntax `"${tinkerforge::bindings_FRAMEWORKS}"` (cmake 3.17.1) 🤷‍♂️ 
